### PR TITLE
Bump version of giphy-api to latest.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/patsissons/hubot-giphy/issues"
   },
   "dependencies": {
-    "giphy-api": "~1.1.17"
+    "giphy-api": "^2.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1252,9 +1252,9 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-giphy-api@~1.1.17:
-  version "1.1.17"
-  resolved "https://registry.yarnpkg.com/giphy-api/-/giphy-api-1.1.17.tgz#2c9dad2dce0c2469b02e01035ff2d30aa6aa6702"
+giphy-api@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/giphy-api/-/giphy-api-2.0.0.tgz#54ecfdfe147e8c57b9c10c20eed84d29571327c6"
 
 glob-base@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Very sorry that I broke your tests a while back. Totally forgot to address the issue in my repo. I fixed this issue: https://github.com/austinkelleher/giphy-api/issues/41.

`giphy-api@2.0.0` simply drops support for old versions of Node and bumps dependencies. See: https://github.com/austinkelleher/giphy-api/pull/51

The original issue was also included in `giphy-api@1.x.x`

/cc @TimvdLippe @patsissons 
